### PR TITLE
Fix getting recent projects from additionalInfo map

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -57,14 +57,15 @@ def get_proj(path):
             if o.attrib["name"] == 'additionalInfo':
                 add_info = o[0]
 
-    if len(items) == 0:
-        return []
-
     if add_info is not None:
         for i in add_info:
             for o in i[0][0]:
                 if o.tag == 'option' and 'name' in o.attrib and o.attrib["name"] == 'projectOpenTimestamp':
                     items[i.attrib["key"]] = int(o.attrib["value"])
+
+    if len(items) == 0:
+        return []
+
     return [(items[e], e.replace("$USER_HOME$", HOME_DIR)) for e in items]
 
 


### PR DESCRIPTION
Hey @mqus, it seems we missed this one, if `recentPaths` are missing (2020.3), the items array is not filled in and it won't proceed with the `additionalInfo` map which is currently the only one present for me in 2020.3.

I am still not sure whether it would be better to put the additionalInfo loop inside `if len(items) == 0:`, but for now, this works fine. However I hope it won't create duplicates for people on the older jetbrains branches.